### PR TITLE
Modify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ RUN dnf --enablerepo crb install -y \
         binutils gcc gnu-efi gnu-efi-devel make redhat-rpm-config rpm-build yum-utils \
         wget dos2unix elfutils-libelf-devel git openssl openssl-devel pesign
 COPY rpmmacros /root/.rpmmacros
-RUN wget https://pjones.fedorapeople.org/rhel-9-x64-20231201/shim-unsigned-x64-15.8-2.el9.src.rpm
-RUN rpm -ivh shim-unsigned-x64-15.8-2.el9.src.rpm
+RUN mkdir -p /builddir/build/{SOURCES,SPECS}
+RUN wget -P /builddir/build/SOURCES https://github.com/rhboot/shim/releases/download/15.8/shim-15.8.tar.bz2
 COPY sbat.ml.csv /builddir/build/SOURCES/
 COPY vendordb.esl /builddir/build/SOURCES/
-RUN sed -i 's/linux32 -B/linux32/g' /builddir/build/SPECS/shim-unsigned-x64.spec
-RUN sed -i 's/sbat.redhat.csv/sbat.ml.csv/g' /builddir/build/SPECS/shim-unsigned-x64.spec
-RUN sed -i 's/^\(Release:.*\)$/\1.ML.1/g' /builddir/build/SPECS/shim-unsigned-x64.spec
+COPY shim-find-debuginfo.sh /builddir/build/SOURCES/
+COPY shim.patches /builddir/build/SOURCES/
+COPY shim-unsigned-x64.spec /builddir/build/SPECS
 RUN rpmbuild -bb /builddir/build/SPECS/shim-unsigned-x64.spec
 COPY shimx64.efi /
 RUN rpm2cpio /builddir/build/RPMS/x86_64/shim-unsigned-x64-15.8-2.el9.ML.1.x86_64.rpm | cpio -diu

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux:9
+FROM almalinux:9.5
 RUN dnf --enablerepo crb install -y \
         binutils gcc gnu-efi gnu-efi-devel make redhat-rpm-config rpm-build yum-utils \
         wget dos2unix elfutils-libelf-devel git openssl openssl-devel pesign

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN dnf --enablerepo crb install -y \
 COPY rpmmacros /root/.rpmmacros
 RUN mkdir -p /builddir/build/{SOURCES,SPECS}
 RUN wget -P /builddir/build/SOURCES https://github.com/rhboot/shim/releases/download/15.8/shim-15.8.tar.bz2
+RUN cd /builddir/build/SOURCES && echo "a79f0a9b89f3681ab384865b1a46ab3f79d88b11b4ca59aa040ab03fffae80a9  shim-15.8.tar.bz2" | sha256sum -c -
 COPY sbat.ml.csv /builddir/build/SOURCES/
 COPY vendordb.esl /builddir/build/SOURCES/
 COPY shim-find-debuginfo.sh /builddir/build/SOURCES/

--- a/shim-find-debuginfo.sh
+++ b/shim-find-debuginfo.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# shim-find-debuginfo.sh
+# Copyright (C) 2017 Peter Jones <Peter Jones@random>
+#
+# Distributed under terms of the GPLv3 license.
+#
+set -e
+set -u
+
+mainarch=$1 && shift
+if [ $# == 1 ]; then
+    altarch=$1 && shift
+fi
+if ! [ -v RPM_BUILD_ROOT ]; then
+    echo "RPM_BUILD_ROOT must be set" 1>&2
+    exit 1
+fi
+
+findsource()
+{
+    (
+        cd "${RPM_BUILD_ROOT}"
+        find usr/src/debug/ -type d | sed -e "s,^,%dir /," | sort -u | tac
+        find usr/src/debug/ -type f | sed -e "s,^,/," | sort -u | tac
+    )
+}
+
+finddebug()
+{
+    arch=$1 && shift
+    declare -a dirs=()
+    declare -a files=()
+    declare -a excludes=()
+    declare -a tmp=()
+
+    pushd "${RPM_BUILD_ROOT}" >/dev/null 2>&1
+
+    mapfile -t tmp < <(find usr/lib/debug/ -type f -iname "*.efi.debug")
+    for x in "${tmp[@]}" ; do
+        if ! [ -e "${x}" ]; then
+            break
+        fi
+        if [[ ${x} =~ ${arch}\.efi\.debug$ ]]; then
+            files[${#files[@]}]=${x}
+        else
+            excludes[${#excludes[@]}]=${x}
+        fi
+    done
+    for x in usr/lib/debug/.build-id/*/*.debug ; do
+        if ! [ -e "${x}" ]; then
+            break
+        fi
+        link=$(readlink "${x}")
+        if [[ ${link} =~ ${arch}\.efi\.debug$ ]]; then
+            files[${#files[@]}]=${x}
+            files[${#files[@]}]=${x%%.debug}
+        else
+            excludes[${#excludes[@]}]=${x}
+            excludes[${#excludes[@]}]=${x%%.debug}
+        fi
+    done
+    for x in "${files[@]}" ; do
+        declare name
+
+        name=$(dirname "/${x}")
+        while [ "${name}" != "/" ]; do
+            case "${name}" in
+            "/usr/lib/debug"|"/usr/lib"|"/usr")
+                ;;
+            *)
+                dirs[${#dirs[@]}]=${name}
+                ;;
+            esac
+            name=$(dirname "${name}")
+        done
+    done
+
+    popd >/dev/null 2>&1
+    for x in "${dirs[@]}" ; do
+        echo "%dir ${x}"
+    done | sort | uniq
+    for x in "${files[@]}" ; do
+        echo "/${x}"
+    done | sort | uniq
+    for x in "${excludes[@]}" ; do
+        echo "%exclude /${x}"
+    done
+}
+
+findsource > "build-${mainarch}/debugsource.list"
+finddebug "${mainarch}" > "build-${mainarch}/debugfiles.list"
+if [ -v altarch ]; then
+    finddebug "${altarch}" > "build-${altarch}/debugfiles.list"
+fi

--- a/shim-unsigned-x64.spec
+++ b/shim-unsigned-x64.spec
@@ -1,0 +1,274 @@
+%global mlrelease .ML.1
+%global pesign_vre 0.106-1
+%global openssl_vre 1.0.2j
+
+%global efidir %(eval echo $(grep ^ID= /etc/os-release | sed -e 's/^ID=//' -e 's/rhel/redhat/'))
+%global shimrootdir %{_datadir}/shim/
+%global shimversiondir %{shimrootdir}/%{version}-%{release}
+%global efiarch x64
+%global shimdir %{shimversiondir}/%{efiarch}
+%global efialtarch ia32
+%global shimaltdir %{shimversiondir}/%{efialtarch}
+
+%global debug_package %{nil}
+%global __debug_package 1
+%global _binaries_in_noarch_packages_terminate_build 0
+%global __debug_install_post %{SOURCE100} %{efiarch} %{efialtarch}
+%undefine _debuginfo_subpackages
+
+# currently here's what's in our dbx: nothing
+%global dbxfile %{nil}
+
+Name:		shim-unsigned-%{efiarch}
+Version:	15.8
+Release:	2.el9%{mlrelease}
+Summary:	First-stage UEFI bootloader
+ExclusiveArch:	x86_64
+License:	BSD
+URL:		https://github.com/rhboot/shim
+Source0:	https://github.com/rhboot/shim/releases/download/%{version}/shim-%{version}.tar.bz2
+Source1:	vendordb.esl
+%if 0%{?dbxfile}
+Source2:	%{dbxfile}
+%endif
+Source3:	sbat.ml.csv
+Source4:	shim.patches
+
+Source100:	shim-find-debuginfo.sh
+
+%include %{SOURCE4}
+
+BuildRequires:	gcc make
+BuildRequires:	elfutils-libelf-devel
+BuildRequires:	git openssl-devel openssl
+BuildRequires:	pesign >= %{pesign_vre}
+BuildRequires:	dos2unix findutils
+
+# Shim uses OpenSSL, but cannot use the system copy as the UEFI ABI is not
+# compatible with SysV (there's no red zone under UEFI) and there isn't a
+# POSIX-style C library.
+# BuildRequires:	OpenSSL
+Provides:	bundled(openssl) = %{openssl_vre}
+
+%global desc \
+Initial UEFI bootloader that handles chaining to a trusted full \
+bootloader under secure boot environments.
+%global debug_desc \
+This package provides debug information for package %{expand:%%{name}} \
+Debug information is useful when developing applications that \
+use this package or when debugging this package.
+
+%description
+%desc
+
+%package -n shim-unsigned-%{efialtarch}
+Summary:	First-stage UEFI bootloader (unsigned data)
+Provides:	bundled(openssl) = %{openssl_vre}
+
+%description -n shim-unsigned-%{efialtarch}
+%desc
+
+%package debuginfo
+Summary:	Debug information for shim-unsigned-%{efiarch}
+Group:		Development/Debug
+AutoReqProv:	0
+BuildArch:	noarch
+
+%description debuginfo
+%debug_desc
+
+%package -n shim-unsigned-%{efialtarch}-debuginfo
+Summary:	Debug information for shim-unsigned-%{efialtarch}
+Group:		Development/Debug
+AutoReqProv:	0
+BuildArch:	noarch
+
+%description -n shim-unsigned-%{efialtarch}-debuginfo
+%debug_desc
+
+%package debugsource
+Summary:	Debug Source for shim-unsigned
+Group:		Development/Debug
+AutoReqProv:	0
+BuildArch:	noarch
+
+%description debugsource
+%debug_desc
+
+%prep
+%autosetup -S git_am -n shim-%{version}
+git config --unset user.email
+git config --unset user.name
+mkdir build-%{efiarch}
+mkdir build-%{efialtarch}
+cp %{SOURCE3} data/
+
+%build
+COMMIT_ID=5914984a1ffeab841f482c791426d7ca9935a5e6
+MAKEFLAGS="TOPDIR=.. -f ../Makefile COMMIT_ID=${COMMIT_ID} "
+MAKEFLAGS+="EFIDIR=%{efidir} PKGNAME=shim RELEASE=%{release} "
+MAKEFLAGS+="ENABLE_SHIM_HASH=true "
+MAKEFLAGS+="SBAT_AUTOMATIC_DATE=2023012900 "
+MAKEFLAGS+="%{_smp_mflags}"
+if [ -f "%{SOURCE1}" ]; then
+	MAKEFLAGS="$MAKEFLAGS VENDOR_DB_FILE=%{SOURCE1}"
+fi
+%if 0%{?dbxfile}
+if [ -f "%{SOURCE2}" ]; then
+	MAKEFLAGS="$MAKEFLAGS VENDOR_DBX_FILE=%{SOURCE2}"
+fi
+%endif
+
+cd build-%{efiarch}
+make ${MAKEFLAGS} \
+	DEFAULT_LOADER='\\\\grub%{efiarch}.efi' \
+	all
+cd ..
+
+%install
+COMMIT_ID=5914984a1ffeab841f482c791426d7ca9935a5e6
+MAKEFLAGS="TOPDIR=.. -f ../Makefile COMMIT_ID=${COMMIT_ID} "
+MAKEFLAGS+="EFIDIR=%{efidir} PKGNAME=shim RELEASE=%{release} "
+MAKEFLAGS+="ENABLE_SHIM_HASH=true "
+MAKEFLAGS+="SBAT_AUTOMATIC_DATE=2023012900 "
+if [ -f "%{SOURCE1}" ]; then
+	MAKEFLAGS="$MAKEFLAGS VENDOR_DB_FILE=%{SOURCE1} "
+fi
+%if 0%{?dbxfile}
+if [ -f "%{SOURCE2}" ]; then
+	MAKEFLAGS="$MAKEFLAGS VENDOR_DBX_FILE=%{SOURCE2} "
+fi
+%endif
+
+cd build-%{efiarch}
+make ${MAKEFLAGS} \
+	DEFAULT_LOADER='\\\\grub%{efiarch}.efi' \
+	DESTDIR=${RPM_BUILD_ROOT} \
+	install-as-data install-debuginfo install-debugsource
+cd ..
+
+%files
+%license COPYRIGHT
+%dir %{shimrootdir}
+%dir %{shimversiondir}
+%dir %{shimdir}
+%{shimdir}/*.efi
+%{shimdir}/*.hash
+%{shimdir}/*.CSV
+
+%files debuginfo -f build-%{efiarch}/debugfiles.list
+
+%files debugsource -f build-%{efiarch}/debugsource.list
+
+%changelog
+* Thu May 09 2024 Masayuki Moriyama <masayuki.moriyama@miraclelinux.com> - 15.8-2.el9.ML.1
+- Replace vendordb.esl file for MIRACLE LINUX release
+- Replace sbat data for MIRACLE LINUX release
+
+* Wed Feb 07 2024 Peter Jones <pjones@redhat.com> - 15.8-2.el9
+- Rebuild to fix the commit ident and MAKEFLAGS
+  Resolves: RHEL-11262
+
+* Tue Jan 23 2024 Peter Jones <pjones@redhat.com> - 15.8-1.el9
+- Update to shim-15.8 for CVE-2023-40547
+  Resolves: RHEL-11262
+
+* Wed Jun 01 2022 Peter Jones <pjones@redhat.com> - 15.6-1.el9
+- Update to shim-15.6 for CVE-2022-28737
+
+* Tue May 24 2022 Peter Jones <pjones@redhat.com> - 15.6~rc1-1.el9
+- Update to shim-15.6~rc1 for CVE-2022-28737
+
+* Wed Mar 09 2022 Peter Jones <pjones@redhat.com> - 15.5-1
+- Update to shim-15.5
+  Related: rhbz#1932057
+
+* Thu Apr 01 2021 Peter Jones <pjones@redhat.com> - 15.4-4
+- Fix the sbat data to actually match /this/ product.
+  Resolves: CVE-2020-14372
+  Resolves: CVE-2020-25632
+  Resolves: CVE-2020-25647
+  Resolves: CVE-2020-27749
+  Resolves: CVE-2020-27779
+  Resolves: CVE-2021-20225
+  Resolves: CVE-2021-20233
+
+* Wed Mar 31 2021 Peter Jones <pjones@redhat.com> - 15.4-3
+- Build with the correct certificate trust list for this OS.
+  Resolves: CVE-2020-14372
+  Resolves: CVE-2020-25632
+  Resolves: CVE-2020-25647
+  Resolves: CVE-2020-27749
+  Resolves: CVE-2020-27779
+  Resolves: CVE-2021-20225
+  Resolves: CVE-2021-20233
+
+* Wed Mar 31 2021 Peter Jones <pjones@redhat.com> - 15.4-2
+- Fix the ia32 build.
+  Resolves: CVE-2020-14372
+  Resolves: CVE-2020-25632
+  Resolves: CVE-2020-25647
+  Resolves: CVE-2020-27749
+  Resolves: CVE-2020-27779
+  Resolves: CVE-2021-20225
+  Resolves: CVE-2021-20233
+
+* Tue Mar 30 2021 Peter Jones <pjones@redhat.com> - 15.4-1
+- Update to shim 15.4
+  - Support for revocations via the ".sbat" section and SBAT EFI variable
+  - A new unit test framework and a bunch of unit tests
+  - No external gnu-efi dependency
+  - Better CI
+  Resolves: CVE-2020-14372
+  Resolves: CVE-2020-25632
+  Resolves: CVE-2020-25647
+  Resolves: CVE-2020-27749
+  Resolves: CVE-2020-27779
+  Resolves: CVE-2021-20225
+  Resolves: CVE-2021-20233
+
+* Wed Mar 24 2021 Peter Jones <pjones@redhat.com> - 15.3-0~1
+- Update to shim 15.3
+  - Support for revocations via the ".sbat" section and SBAT EFI variable
+  - A new unit test framework and a bunch of unit tests
+  - No external gnu-efi dependency
+  - Better CI
+  Resolves: CVE-2020-14372
+  Resolves: CVE-2020-25632
+  Resolves: CVE-2020-25647
+  Resolves: CVE-2020-27749
+  Resolves: CVE-2020-27779
+  Resolves: CVE-2021-20225
+  Resolves: CVE-2021-20233
+
+* Wed Jun 05 2019 Javier Martinez Canillas <javierm@redhat.com> - 15-3
+- Make EFI variable copying fatal only on secureboot enabled systems
+  Resolves: rhbz#1715878
+- Fix booting shim from an EFI shell using a relative path
+  Resolves: rhbz#1717064
+
+* Tue Feb 12 2019 Peter Jones <pjones@redhat.com> - 15-2
+- Fix MoK mirroring issue which breaks kdump without intervention
+  Related: rhbz#1668966
+
+* Thu Apr 05 2018 Peter Jones <pjones@redhat.com> - 15-1
+- Update to shim 15
+- better checking for bad linker output
+- flicker-free console if there's no error output
+- improved http boot support
+- better protocol re-installation
+- dhcp proxy support
+- tpm measurement even when verification is disabled
+- REQUIRE_TPM build flag
+- more reproducable builds
+- measurement of everything verified through shim_verify()
+- coverity and scan-build checker make targets
+- misc cleanups
+
+* Fri Feb 09 2018 Fedora Release Engineering <releng@fedoraproject.org> - 13-0.2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild
+
+* Fri Aug 18 2017 Peter Jones <pjones@redhat.com> - 13-0.1
+- Make a new shim-unsigned-x64 package like the shim-unsigned-aarch64 one.
+- This will (eventually) supersede what's in the "shim" package so we can
+  make "shim" hold the signed one, which will confuse fewer people.


### PR DESCRIPTION
I fixed the following two reviewer comments in the Dockerfile:

https://github.com/rhboot/shim-review/issues/421#issuecomment-2336738691
steve-mcintyre wrote on Sep 9, 2024:
> -  I don't see why you're grabbing Peter's
> shim-unsigned-x64-15.8-2.el9.src.rpm rather than just using the
> upstream shim tarball directly. This isn't a blocker for this review
> as it's possible to check the tarball checksum from the
> src.rpm. Please don't do this again, though.

https://github.com/rhboot/shim-review/issues/421#issuecomment-2558496960
aronowski wrote on Dec 23, 2024:
> Prefer using older minor system releases - the shim binary build does reproduce correctly now, but in case new tooling gets shipped as part of EL9.6, that can change unexpectedly.
